### PR TITLE
WaveMix multi-gpu cuda fix

### DIFF
--- a/wavemix/__init__.py
+++ b/wavemix/__init__.py
@@ -290,8 +290,8 @@ def prep_filt_afb1d(h0, h1, device='cpu'):
     h0 = np.array(h0[::-1]).ravel()
     h1 = np.array(h1[::-1]).ravel()
     t = torch.get_default_dtype()
-    h0 = torch.tensor(h0, device='cpu', dtype=t).reshape((1, 1, -1))
-    h1 = torch.tensor(h1, device='cpu', dtype=t).reshape((1, 1, -1))
+    h0 = torch.tensor(h0, device=device, dtype=t).reshape((1, 1, -1))
+    h1 = torch.tensor(h1, device=device, dtype=t).reshape((1, 1, -1))
     return h0, h1
 
 

--- a/wavemix/__init__.py
+++ b/wavemix/__init__.py
@@ -365,11 +365,14 @@ from numpy.lib.function_base import hamming
 
 
 def get_dwt_filters(level, mode='zero', wave='db1'):   
-    xf1 = DWTForward(J=1, mode=mode, wave=wave)    
-    xf2 = DWTForward(J=2, mode=mode, wave=wave)    
-    xf3 = DWTForward(J=3, mode=mode, wave=wave)   
-    xf4 = DWTForward(J=4, mode=mode, wave=wave)
-    return [xf1, xf2, xf3, xf4][:level]
+    xf = []
+    for j in range(1,level+1,1):
+        xf.append(DWTForward(J=j, mode=mode, wave=wave)
+                  
+    if level == 1: 
+        xf = xf[0]
+        
+    return xf
 
 
 class Level1Waveblock(nn.Module):

--- a/wavemix/classification.py
+++ b/wavemix/classification.py
@@ -2,6 +2,7 @@ from wavemix import Level4Waveblock, Level3Waveblock, Level2Waveblock, Level1Wav
 import torch.nn as nn
 from einops.layers.torch import Rearrange
 
+
 class WaveMix(nn.Module):
     def __init__(
         self,
@@ -22,14 +23,14 @@ class WaveMix(nn.Module):
         
         self.layers = nn.ModuleList([])
         for _ in range(depth): 
-                if level == 4:
-                    self.layers.append(Level4Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
-                elif level == 3:
-                    self.layers.append(Level3Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
-                elif level == 2:
-                    self.layers.append(Level2Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
-                else:
-                    self.layers.append(Level1Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
+            if level == 4:
+                self.layers.append(Level4Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
+            elif level == 3:
+                self.layers.append(Level3Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
+            elif level == 2:
+                self.layers.append(Level2Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
+            else:
+                self.layers.append(Level1Waveblock(mult = mult, ff_channel = ff_channel, final_dim = final_dim, dropout = dropout))
         
         self.pool = nn.Sequential(
             nn.AdaptiveAvgPool2d(1),
@@ -49,8 +50,7 @@ class WaveMix(nn.Module):
             nn.Conv2d(int(final_dim/2), final_dim, patch_size, patch_size),
             nn.GELU(),
             nn.BatchNorm2d(final_dim)
-            )
-        
+            )  
 
     def forward(self, img):
         x = self.conv(img)   


### PR DESCRIPTION
 In the original `wavemix/__init__.py`, some layers are put on 'cuda:0' by default, and this cannot be changed. This behavior is undesirable since upon initialization, some weights are on 'cuda:0' and the rest are on 'cpu', until model.to('cuda:0') is called.

Additionally, on servers with more than one gpu, if gpu 0 is in use, wavemix models cannot be used. There is another bug which prevents conveniently putting the whole model on say 'cuda:4': the `DWTForward` layers are defined outside the `LevelXWaveblock`s and since they are not "children" of the waveblocks, when `waveblock.to('cuda:4')` is called, the xf1, xf2, xf3, xf4 are still on 'cuda:0', causing device mismatch errors.


This patch fixes these issues by changing the default device argument in the defined functions to 'cpu', which makes all weights initialized on 'cpu' at first, and defines xf1, xf2, xf3, xf4 inside their respective waveblocks, which allows waveblock.to('cuda:N') to work as intended.